### PR TITLE
Fix für settings.gradle parsing mit kommaseparierten includes

### DIFF
--- a/dependency/src/main/java/de/peass/dependency/execution/GradleParseUtil.java
+++ b/dependency/src/main/java/de/peass/dependency/execution/GradleParseUtil.java
@@ -230,8 +230,8 @@ public class GradleParseUtil {
    }
 
    private static void parseModuleLine(final File projectFolder, final List<File> modules, final String line) {
-      final String[] splitted = line.replaceAll(" +", " ").split(" ");
-      if (splitted.length == 2 && splitted[0].equals("include")) {
+      final String[] splitted = line.replaceAll(" +"," ").replaceAll(",","").split(" ");
+      if (splitted[0].equals("include")) {
          final String candidate = splitted[1].substring(1, splitted[1].length() - 1);
          final File module = new File(projectFolder, candidate.replace(':', File.separatorChar));
          if (module.exists()) {

--- a/dependency/src/test/java/de/peass/dependency/execution/TestGradleParseUtil.java
+++ b/dependency/src/test/java/de/peass/dependency/execution/TestGradleParseUtil.java
@@ -34,6 +34,13 @@ public class TestGradleParseUtil {
 
       Assert.assertThat(modules.size(), Matchers.is(3));
    }
+   
+   @Test
+   public void testModuleGettingComma() throws FileNotFoundException, IOException {
+      List<File> modules = GradleParseUtil.getModules(new File("src/test/resources/gradle-multimodule-example-comma")).getModules();
+      
+      Assert.assertThat(modules.size(), Matchers.is(2));
+   }
 
    @Test
    public void testSubprojectInstrumentation() throws IOException, XmlPullParserException, InterruptedException {

--- a/dependency/src/test/resources/gradle-multimodule-example-comma/gradle-multimodule-example.gradle
+++ b/dependency/src/test/resources/gradle-multimodule-example-comma/gradle-multimodule-example.gradle
@@ -1,0 +1,24 @@
+buildscript {
+    repositories {
+	jcenter()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+sourceCompatibility = 1.8
+version = '2.13'
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven{
+		url 'https://oss.sonatype.org/content/repositories/snapshots'
+	}
+}
+
+dependencies {
+  testCompile 'junit:junit:4.13.2'
+}

--- a/dependency/src/test/resources/gradle-multimodule-example-comma/myModule1/gradle-multimodule-example.gradle
+++ b/dependency/src/test/resources/gradle-multimodule-example-comma/myModule1/gradle-multimodule-example.gradle
@@ -1,0 +1,24 @@
+buildscript {
+    repositories {
+	jcenter()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+sourceCompatibility = 1.8
+version = '2.13'
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven{
+		url 'https://oss.sonatype.org/content/repositories/snapshots'
+	}
+}
+
+dependencies {
+  testCompile 'junit:junit:4.13.2'
+}

--- a/dependency/src/test/resources/gradle-multimodule-example-comma/myModule2/gradle-multimodule-example.gradle
+++ b/dependency/src/test/resources/gradle-multimodule-example-comma/myModule2/gradle-multimodule-example.gradle
@@ -1,0 +1,24 @@
+buildscript {
+    repositories {
+	jcenter()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+sourceCompatibility = 1.8
+version = '2.13'
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven{
+		url 'https://oss.sonatype.org/content/repositories/snapshots'
+	}
+}
+
+dependencies {
+  testCompile 'junit:junit:4.13.2'
+}

--- a/dependency/src/test/resources/gradle-multimodule-example-comma/settings.gradle
+++ b/dependency/src/test/resources/gradle-multimodule-example-comma/settings.gradle
@@ -1,0 +1,1 @@
+include 'myModule1', 'myModule2'


### PR DESCRIPTION
Das Problem gelöst, bei dem die Zeile `include 'myModule1', 'myModule2'` in `settings.gradle` nicht richtig geparsed wird.
Die Modul-Dateien mit der settings.gradle zu den Tests hinzugefügt und alle Tests laufen erfolgreich.