### PR TITLE
Fixed parameter comparison by adding zero parameter check

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/dependency/traces/ParameterComparator.java
+++ b/dependency/src/main/java/de/dagere/peass/dependency/traces/ParameterComparator.java
@@ -29,7 +29,7 @@ public class ParameterComparator {
    public boolean parametersEqual(final TraceElementContent traceElement, final CallableDeclaration<?> method) {
       if (traceElement.getParameterTypes().length == 0 && method.getParameters().size() == 0) {
          return true;
-      } else if (method.getParameters().size() == 0) {
+      } else if (traceElement.getParameterTypes().length == 0 || method.getParameters().size() == 0) {
          return false;
       }
       int parameterIndex = 0;


### PR DESCRIPTION
Without this fix we may get an ArrayIndexOutOfBoundsException in method ParameterComparator.getCleanedTraceParameters