### PR TITLE
[FIX] Ignore .java file extension for comparing paths in VersionDiff

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/dependency/analysis/data/VersionDiff.java
+++ b/dependency/src/main/java/de/dagere/peass/dependency/analysis/data/VersionDiff.java
@@ -70,9 +70,10 @@ public class VersionDiff {
          setPomChanged(true);
       } else {
          if (currentFileName.endsWith(".java")) {
+            String fileNameWithoutExtension = currentFileName.replace(".java", "");
             String containedPath = null;
             for (String path : config.getAllClazzFolders()) {
-               if (currentFileName.contains(path)) {
+               if (fileNameWithoutExtension.contains(path)) {
                   containedPath = path;
                   break;
                }


### PR DESCRIPTION
Required for using '-classFolder java'