### PR TITLE
[FIX] Do not use bimodal ttest for rca and getchanges

### DIFF
--- a/analysis/src/main/java/de/dagere/peass/visualization/NodePreparator.java
+++ b/analysis/src/main/java/de/dagere/peass/visualization/NodePreparator.java
@@ -228,7 +228,6 @@ public class NodePreparator {
       if (measuredNode.getStatistic().getMeanCurrent() > 0.001 && measuredNode.getStatistic().getMeanOld() > 0.001) {
          CompareData cd = new CompareData(measuredNode.getValuesPredecessor().getValuesArray(), measuredNode.getValues().getValuesArray());
          MeasurementConfig measurementConfig = new MeasurementConfig(-1);
-         measurementConfig.getStatisticsConfig().setStatisticTest(ImplementedTests.BIMODAL_T_TEST);
          boolean isChange = StatisticUtil.isDifferent(cd, measurementConfig) != Relation.EQUAL;
 //         final boolean isChange = StatisticUtil.isChange(statisticsOld, statisticsCurrent, data.getMeasurementConfig()) == Relation.UNEQUAL;
          if (isChange) {

--- a/measurement/src/main/java/de/dagere/peass/measurement/statistics/StatisticUtil.java
+++ b/measurement/src/main/java/de/dagere/peass/measurement/statistics/StatisticUtil.java
@@ -247,6 +247,11 @@ public class StatisticUtil {
       return shortenedValues;
    }
 
+   public static Relation tTest(final List<Result> valuesPrev, final List<Result> valuesVersion, final double type1error) {
+      CompareData data = new CompareData(valuesPrev, valuesVersion);
+      return getTTestRelation(data, type1error);
+   }
+
    public static Relation getTTestRelation(final CompareData cd, final double type1error) {
       final boolean tchange = new TTest().homoscedasticTTest(cd.getBefore(), cd.getAfter(), type1error);
       if (tchange) {

--- a/measurement/src/main/java/de/dagere/peass/measurement/statistics/data/DescribedChunk.java
+++ b/measurement/src/main/java/de/dagere/peass/measurement/statistics/data/DescribedChunk.java
@@ -68,7 +68,7 @@ public class DescribedChunk {
 
    public TestcaseStatistic getStatistic(final double type1error, final double type2error) {
 //      final boolean isChange = StatisticUtil.agnosticTTest(descPrev, descCurrent, type1error, type2error) == de.peass.measurement.analysis.Relation.UNEQUAL;
-      final boolean isChange = StatisticUtil.bimodalTTest(previous, current, type1error) != de.dagere.peass.measurement.statistics.Relation.EQUAL;
+      final boolean isChange = StatisticUtil.tTest(previous, current, type1error) != de.dagere.peass.measurement.statistics.Relation.EQUAL;
       TestcaseStatistic statistic = new TestcaseStatistic(descPrev, descCurrent, descPrev.getN(), descCurrent.getN());
       statistic.setChange(isChange);
       statistic.setIsBimodal(StatisticUtil.isBimodal(previous, current));


### PR DESCRIPTION
**First Change**
The class `StatisticConfig` already contains the following line:

`private ImplementedTests statisticTest = ImplementedTests.T_TEST;`

In my opinion, we should not use a hardcoded value in a "random" method to change the default statistic test.

**Second change**
We use ttest as default for measurements. This is the reason why we should also use ttest for determination of changes (i.e. getchanges command).