### PR TITLE
[Fix] comparison with java.lang class names

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/dependency/changesreading/FQNDeterminer.java
+++ b/dependency/src/main/java/de/dagere/peass/dependency/changesreading/FQNDeterminer.java
@@ -54,7 +54,7 @@ public class FQNDeterminer {
          return importedType;
       }
 
-      if (JAVA_LANG_CLASSES_SET.contains(typeName)) {
+      if (JAVA_LANG_CLASSES_SET.contains(typeName) || JAVA_LANG_CLASSES_SET.contains(typeName + "<T>")) {
          return "java.lang." + typeName;
       } else {
          String packageName = unit.getPackageDeclaration().get().getNameAsString();

--- a/dependency/src/test/java/de/dagere/peass/dependency/changesreading/TestFQNDeterminer.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/changesreading/TestFQNDeterminer.java
@@ -79,4 +79,12 @@ public class TestFQNDeterminer {
       String fqn2 = FQNDeterminer.getParameterFQN(unit, "String");
       Assert.assertEquals("java.lang.String", fqn2);
    }
+
+   @Test
+   public void testJavaLangGenericClass() throws FileNotFoundException {
+      File file = new File("src/main/java/de/dagere/peass/SelectStarter.java");
+      CompilationUnit unit = JavaParserProvider.parse(file);
+      String fqn = FQNDeterminer.getParameterFQN(unit, "Class");
+      Assert.assertEquals("java.lang.Class", fqn);
+   }
 }


### PR DESCRIPTION
**Description**
Some classes of java.lang use type parameters. Since the type parameter of the variable `typeName` was removed before, we need to add it again for the comparison.