### PR TITLE
Use correct peass-jmh version in peass-starter

### DIFF
--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>de.dagere.peass</groupId>
       <artifactId>peass-jmh</artifactId>
-      <version>0.1.7-SNAPSHOT</version>
+      <version>0.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.dagere.peass</groupId>


### PR DESCRIPTION
Set version of peass-jmh to 0.2.0-SNAPSHOT in peass-starter.