### PR TITLE
Using peass 0.2.1-SNAPSHOT in peass-jmh

### DIFF
--- a/peass-jmh/pom.xml
+++ b/peass-jmh/pom.xml
@@ -86,12 +86,12 @@
     <dependency>
       <groupId>de.dagere.peass</groupId>
       <artifactId>dependency</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.dagere.peass</groupId>
       <artifactId>dependency</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.1-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Increased version of peass-dependency in peass-jmh. So changes in peass-dependency will not be overwritten by an older version if peass-jmh is built.