### PR TITLE
Dont use getIntegrationTestLine in GradleBuildfileEditor.enhanceTestTask

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -169,7 +169,7 @@ public class GradleBuildfileEditor {
                visitor.addLine(visitor.getTestSystemPropertiesLine(), "  '" + entry.getKey() + "'             : '" + entry.getValue() + "',");
             }
             if (argLineBuilder.getJVMArgs() != null) {
-               visitor.addLine(visitor.getIntegrationTestLine(), argLineBuilder.getJVMArgs());
+               visitor.addLine(visitor.getTestLine(), argLineBuilder.getJVMArgs());
             }
 
          }


### PR DESCRIPTION
GradleBuildfileEditor.enhanceTestTask must use visitor.getTestLine(), not visitor.getIntegrationTestLine()