### PR TITLE
Fix Testcase Pattern Generation Method

### DIFF
--- a/measurement/src/main/java/de/dagere/peass/measurement/rca/PatternSetGenerator.java
+++ b/measurement/src/main/java/de/dagere/peass/measurement/rca/PatternSetGenerator.java
@@ -45,8 +45,9 @@ public class PatternSetGenerator {
    }
 
    private void addIncludedPattern(CallTreeNode node, String addPattern, Set<String> includedPattern) {
-      if (node.getCall().equals(testcase.getExecutable()) && !addPattern.startsWith("public ")) {
-         includedPattern.add("public " + addPattern);
+      if (node.getCall().equals(testcase.getExecutable()) && addPattern.startsWith("public ")) {
+         includedPattern.add(addPattern.substring("public ".length()));
+         includedPattern.add(addPattern);
       } else {
          includedPattern.add(addPattern);
       }

--- a/measurement/src/test/java/de/dagere/peass/measurement/rca/TestPatternSetGenerator.java
+++ b/measurement/src/test/java/de/dagere/peass/measurement/rca/TestPatternSetGenerator.java
@@ -22,12 +22,13 @@ public class TestPatternSetGenerator {
       PatternSetGenerator generator = new PatternSetGenerator(config, new TestCase("de.pack.Clazz#myTest"));
       
       HashSet<CallTreeNode> includedNodes = new HashSet<>();
-      includedNodes.add(new CallTreeNode("de.pack.Clazz#myTest", "void de.pack.Clazz.myTest()", "void de.pack.Clazz.myTest()", new MeasurementConfig(5)));
+      includedNodes.add(new CallTreeNode("de.pack.Clazz#myTest", "public void de.pack.Clazz.myTest()", "public void de.pack.Clazz.myTest()", new MeasurementConfig(5)));
       includedNodes.add(new CallTreeNode("de.core.Clazz#myMethod", "public void de.core.Clazz.myMethod(int a)", "public void de.core.Clazz.myMethod(int a)", new MeasurementConfig(5)));
       
       Set<String> patternSet = generator.generatePatternSet(includedNodes, "000001");
       
       MatcherAssert.assertThat(patternSet, IsIterableContaining.hasItem("public void de.core.Clazz.myMethod(int a)"));
+      MatcherAssert.assertThat(patternSet, IsIterableContaining.hasItem("void de.pack.Clazz.myTest()"));
       MatcherAssert.assertThat(patternSet, IsIterableContaining.hasItem("public void de.pack.Clazz.myTest()"));
    }
 }


### PR DESCRIPTION
If a test method has default visibility, peass transformed it to a public method. Thereby, patterns were generated with public modifier, but had no modifier. This PR fixes this issue by removing public from the pattern.