### PR TITLE
fix result reading for method with default visibility

### DIFF
--- a/measurement/src/main/java/de/dagere/peass/measurement/rca/kieker/KiekerResultReader.java
+++ b/measurement/src/main/java/de/dagere/peass/measurement/rca/kieker/KiekerResultReader.java
@@ -111,7 +111,7 @@ public class KiekerResultReader {
    private boolean isSameNode(final CallTreeNode node, final String nodeCall, final AggregatedDataNode measuredNode) {
       final String kiekerCall = KiekerPatternConverter.getKiekerPattern(measuredNode.getCall());
       LOG.trace("Node: {} Kieker: {} Equal: {}", nodeCall, kiekerCall, nodeCall.equals(kiekerCall));
-      if (nodeCall.equals(kiekerCall)) {
+      if (nodeCall.equals(kiekerCall) || isSameNodeWithoutModifier(nodeCall, kiekerCall)) {
          LOG.trace("EOI: {} vs {}", node.getEoi(version), measuredNode.getEoi());
          if (considerNodePosition) {
             final int eoi = node.getEoi(version);
@@ -134,5 +134,11 @@ public class KiekerResultReader {
       } else if (usedRecord == AllowedKiekerRecord.DURATION) {
          KiekerDurationReader.executeReducedDurationStage(kiekerTraceFolder, includedNodes, version);
       }
+   }
+
+   private boolean isSameNodeWithoutModifier(String nodeCall, String kiekerCall) {
+      String executable = testcase.getExecutable().replace("#", ".");
+      String pureCall = nodeCall.substring("public ".length());
+      return nodeCall.contains(executable) && pureCall.equals(kiekerCall);
    }
 }


### PR DESCRIPTION
If a test method has default visibility, peass creates tree nodes with public modifier, but test had no modifier. This PR fixes this issue.