### PR TITLE
Cleaning

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/config/ExecutionConfig.java
+++ b/dependency/src/main/java/de/dagere/peass/config/ExecutionConfig.java
@@ -453,26 +453,6 @@ public class ExecutionConfig implements Serializable {
       }
    }
 
-   private static final class GradleJavaPluginNameFilter {
-      @Override
-      public boolean equals(Object obj) {
-         if (obj instanceof String && GRADLE_JAVA_DEFAULT_NAME.equals(obj)) {
-            return true;
-         }
-         return super.equals(obj);
-      }
-   }
-
-   private static final class SpringBootPluginNameFilter {
-      @Override
-      public boolean equals(Object obj) {
-         if (obj instanceof String && GRADLE_SPRING_DEFAULT_NAME.equals(obj)) {
-            return true;
-         }
-         return super.equals(obj);
-      }
-   }
-
    private static final class ClazzFoldersFilter {
       @Override
       public boolean equals(Object obj) {

--- a/dependency/src/main/java/de/dagere/peass/config/ExecutionConfig.java
+++ b/dependency/src/main/java/de/dagere/peass/config/ExecutionConfig.java
@@ -18,10 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ExecutionConfig implements Serializable {
 
-   public static final String GRADLE_JAVA_DEFAULT_NAME = "java";
-
-   public static final String GRADLE_SPRING_DEFAULT_NAME = "org.springframework.boot";
-
    public static final String CLASSPATH_SEPARATOR = ":";
 
    public static final String DEFAULT_TEST_TRANSFORMER = "de.dagere.peass.testtransformation.JUnitTestTransformer";

--- a/dependency/src/main/java/de/dagere/peass/config/ExecutionConfig.java
+++ b/dependency/src/main/java/de/dagere/peass/config/ExecutionConfig.java
@@ -34,6 +34,8 @@ public class ExecutionConfig implements Serializable {
    public static final String SRC_TEST = "src/test";
    public static final String SRC_ANDROID_TEST_JAVA = "src/androidTest/java/";
 
+   public static final int DEFAULT_KIEKER_WAIT_TIME = 5;
+
    private static final long serialVersionUID = -6642358125854337047L;
 
    /**
@@ -53,7 +55,7 @@ public class ExecutionConfig implements Serializable {
    protected String startcommit;
    protected String endcommit;
    private String pl;
-   private int kiekerWaitTime = 10;
+   private int kiekerWaitTime = DEFAULT_KIEKER_WAIT_TIME;
 
    private boolean redirectSubprocessOutputToFile = true;
    private boolean useTieredCompilation = false;

--- a/dependency/src/main/java/de/dagere/peass/config/parameters/ExecutionConfigMixin.java
+++ b/dependency/src/main/java/de/dagere/peass/config/parameters/ExecutionConfigMixin.java
@@ -9,6 +9,7 @@ import picocli.CommandLine.Option;
 public class ExecutionConfigMixin {
    public final static String CLAZZ_FOLDERS_DEFAULT = ExecutionConfig.SRC_MAIN_JAVA + ":" + ExecutionConfig.SRC_JAVA;
    public final static String TEST_FOLDERS_DEFAULT = ExecutionConfig.SRC_TEST_JAVA + ":" + ExecutionConfig.SRC_TEST + ":" + ExecutionConfig.SRC_ANDROID_TEST_JAVA;
+   public final static int DEFAULT_KIEKER_WAIT_TIME = ExecutionConfig.DEFAULT_KIEKER_WAIT_TIME;
 
    @Option(names = { "-timeout", "--timeout" }, description = "Timeout in minutes for each VM start")
    protected int timeout = 5;
@@ -77,7 +78,7 @@ public class ExecutionConfigMixin {
    protected boolean useAlternativeBuildfile = false;
 
    @Option(names = { "-kiekerWaitTime", "--kiekerWaitTime" }, description = "Time that KoPeMe should wait until Kieker writing is finshed in seconds (default: 10)")
-   protected int kiekerWaitTime = 5;
+   protected int kiekerWaitTime = DEFAULT_KIEKER_WAIT_TIME;
 
    @Option(names = { "-classFolder", "--classFolder" }, description = "Folder that contains java classes")
    protected String clazzFolder = CLAZZ_FOLDERS_DEFAULT;


### PR DESCRIPTION
Use same DEFAULT_KIEKER_WAIT_TIME in ExecutionConfig and ExecutionConfigMixin.

Removed unused GradleJavaPluginNameFilter, SpringBootPluginNameFilter, GRADLE_JAVA_DEFAULT_NAME and GRADLE_SPRING_DEFAULT_NAME from ExecutionConfig.