### PR TITLE
Made setting of GIT_CRYPT_KEY work with peass-ci-plugin

### DIFF
--- a/analysis/src/main/java/de/dagere/peass/ci/ContinuousExecutor.java
+++ b/analysis/src/main/java/de/dagere/peass/ci/ContinuousExecutor.java
@@ -81,7 +81,7 @@ public class ContinuousExecutor {
 
    private void getGitRepo(final File projectFolder, final MeasurementConfig measurementConfig, final File projectFolderLocal) throws InterruptedException, IOException {
       if (!localFolder.exists() || !projectFolderLocal.exists()) {
-         ContinuousFolderUtil.cloneProject(projectFolder, localFolder);
+         ContinuousFolderUtil.cloneProject(projectFolder, localFolder, measurementConfig.getExecutionConfig().getGitCryptKey());
          if (!projectFolderLocal.exists()) {
             throw new RuntimeException("Was not able to clone project to " + projectFolderLocal.getAbsolutePath() + " (folder not existing)");
          }

--- a/analysis/src/main/java/de/dagere/peass/ci/ContinuousFolderUtil.java
+++ b/analysis/src/main/java/de/dagere/peass/ci/ContinuousFolderUtil.java
@@ -2,7 +2,6 @@ package de.dagere.peass.ci;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,16 +53,9 @@ public enum ContinuousFolderUtil {
       }
 
       if (gitCryptKey != null) {
-         GitUtils.unlockWithGitCrypt(getProjectSubfolder(localFolder), gitCryptKey);
+         GitUtils.unlockWithGitCrypt(new File(localFolder, originalVcsFolder.getName()), gitCryptKey);
       }
 
-   }
-
-   private static File getProjectSubfolder(final File localFolder) {
-      final String projectName_fullPeass = Paths.get(localFolder.getAbsolutePath()).getFileName().toString();
-      final String projectName = projectName_fullPeass.substring(0, projectName_fullPeass.length() - new String("_fullPeass").length());
-      final File projectFolder = new File(localFolder, projectName);
-      return projectFolder;
    }
 
    private static void assureProcessFinished(Process process) throws InterruptedException {

--- a/analysis/src/main/java/de/dagere/peass/ci/ContinuousFolderUtil.java
+++ b/analysis/src/main/java/de/dagere/peass/ci/ContinuousFolderUtil.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 
 import de.dagere.peass.folders.PeassFolders;
 import de.dagere.peass.utils.StreamGobbler;
+import de.dagere.peass.vcs.GitUtils;
 import de.dagere.peass.vcs.VersionControlSystem;
 
 public enum ContinuousFolderUtil {
@@ -35,7 +36,7 @@ public enum ContinuousFolderUtil {
       }
    }
 
-   public static void cloneProject(final File cloneProjectFolder, final File localFolder) throws InterruptedException, IOException {
+   public static void cloneProject(final File cloneProjectFolder, final File localFolder, final String gitCryptKey) throws InterruptedException, IOException {
       localFolder.mkdirs();
       File originalVcsFolder = VersionControlSystem.findVCSFolder(cloneProjectFolder);
       if (originalVcsFolder != null && originalVcsFolder.exists()) {
@@ -50,6 +51,11 @@ public enum ContinuousFolderUtil {
          throw new RuntimeException("No git folder in " + cloneProjectFolder.getAbsolutePath() + " (or parent) present - "
                + "currently, only git projects are supported");
       }
+
+      if (gitCryptKey != null) {
+         GitUtils.unlockWithGitCrypt(localFolder, gitCryptKey);
+      }
+
    }
 
    private static void assureProcessFinished(Process process) throws InterruptedException {

--- a/analysis/src/main/java/de/dagere/peass/ci/ContinuousFolderUtil.java
+++ b/analysis/src/main/java/de/dagere/peass/ci/ContinuousFolderUtil.java
@@ -2,6 +2,7 @@ package de.dagere.peass.ci;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,9 +54,16 @@ public enum ContinuousFolderUtil {
       }
 
       if (gitCryptKey != null) {
-         GitUtils.unlockWithGitCrypt(localFolder, gitCryptKey);
+         GitUtils.unlockWithGitCrypt(getProjectSubfolder(localFolder), gitCryptKey);
       }
 
+   }
+
+   private static File getProjectSubfolder(final File localFolder) {
+      final String projectName_fullPeass = Paths.get(localFolder.getAbsolutePath()).getFileName().toString();
+      final String projectName = projectName_fullPeass.substring(0, projectName_fullPeass.length() - new String("_fullPeass").length());
+      final File projectFolder = new File(localFolder, projectName);
+      return projectFolder;
    }
 
    private static void assureProcessFinished(Process process) throws InterruptedException {

--- a/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
+++ b/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
@@ -517,7 +517,7 @@ public final class GitUtils {
       return 0;
    }
 
-   protected static void unlockWithGitCrypt(final File projectFolder, final String gitCryptKey) {
+   public static void unlockWithGitCrypt(final File projectFolder, final String gitCryptKey) {
       LOG.debug("GIT_CRYPT_KEY is set, unlocking repo.");
       final ProcessBuilder processBuilder = new ProcessBuilder("git-crypt", "unlock", gitCryptKey);
       try {

--- a/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
+++ b/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
@@ -534,6 +534,10 @@ public final class GitUtils {
       }
    }
 
+   /*
+    * This will probably not work, if you have a git-Repo inside a git-repo!
+    * e.g. if you run peass-ci-plugin with mvn hpi:run, where your jenkins-workspace is "surrounded" by the peass-ci-plugin-repo
+    */
    protected static boolean checkIsUnlockedWithGitCrypt(final File projectFolder) {
       final ProcessBuilder processBuilder = new ProcessBuilder("git", "config", "--local", "--get", "filter.git-crypt.smudge");
       processBuilder.directory(projectFolder);

--- a/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
+++ b/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
@@ -518,7 +518,7 @@ public final class GitUtils {
    }
 
    public static void unlockWithGitCrypt(final File projectFolder, final String gitCryptKey) {
-      LOG.debug("GIT_CRYPT_KEY is set, unlocking repo.");
+      LOG.debug("GIT_CRYPT_KEY is set, unlocking: {}", projectFolder);
       final ProcessBuilder processBuilder = new ProcessBuilder("git-crypt", "unlock", gitCryptKey);
       try {
          if (processBuilder.directory(projectFolder).start().waitFor() != 0) {
@@ -530,7 +530,7 @@ public final class GitUtils {
 
       if (!checkIsUnlockedWithGitCrypt(projectFolder)) {
          LOG.error("Folder is still locked, something went wrong!");
-         // TODO stop execution?
+         throw new RuntimeException("Folder is still locked, something went wrong!");
       }
    }
 

--- a/dependency/src/test/java/de/dagere/peass/vcs/TestGitUtilsGitCrypt.java
+++ b/dependency/src/test/java/de/dagere/peass/vcs/TestGitUtilsGitCrypt.java
@@ -16,6 +16,9 @@ import net.lingala.zip4j.exception.ZipException;
 
 public class TestGitUtilsGitCrypt {
 
+   /*
+    * disabled, since it does not work in maven release environment
+    */
    @Test
    @DisabledOnOs(OS.WINDOWS)
    @Disabled


### PR DESCRIPTION
Repo is also unlocked in ContinuousFolderUtil if GIT_CRYPT_KEY is set in Environment.
An Exception is thrown, if unlocking did not succeed.
Some comments have been added, why TestGitUtilsGitCrypt.testCheckIsUnlockedWithGitCrypt ist disabled and GitUtils.checkIsUnlockedWithGitCrypt will not work, if jenkins is started with `mvn hpi:run`.