### PR TITLE
Bugfix: Properly recognize Ignore on Classes and methods

### DIFF
--- a/dependency/src/test/java/de/dagere/peass/transformation/TestIgnoredMethodBuilding.java
+++ b/dependency/src/test/java/de/dagere/peass/transformation/TestIgnoredMethodBuilding.java
@@ -38,6 +38,14 @@ public class TestIgnoredMethodBuilding {
       MatcherAssert.assertThat(tests.getTestsToUpdate().getTestMethods(), IsIterableContaining.hasItem(new TestMethodCall("TestMeIgnored", "testMe2")));
    }
 
+   @Test
+   public void testJUnit4IgnoreClass() throws IOException {
+      RunnableTestInformation tests = executeTransformation("TestClassIgnored.java", testFolder);
+
+      MatcherAssert.assertThat(tests.getTestsToUpdate().getTestMethods(), Matchers.not(IsIterableContaining.hasItem(new TestMethodCall("TestClassIgnored", "testMe"))));
+      MatcherAssert.assertThat(tests.getIgnoredTests().getTestMethods(), IsIterableContaining.hasItem(new TestMethodCall("TestClassIgnored", "testMe")));
+   }
+   
    public static RunnableTestInformation executeTransformation(final String currentClassName, final File testFolder) throws IOException {
       File sourcesFolder = initializeProject(testFolder);
 
@@ -52,7 +60,7 @@ public class TestIgnoredMethodBuilding {
       
       tt.determineVersions(mapping.getModules());
       
-      RunnableTestInformation tests = tt.buildTestMethodSet(new TestSet("TestMeIgnored"), mapping);
+      RunnableTestInformation tests = tt.buildTestMethodSet(new TestSet(currentClassName.split("\\.")[0]), mapping);
 
       return tests;
    }


### PR DESCRIPTION
There were two problems:
a) Ignore/disable on class level was not taken into account, when there was only a class change it wasn't taken care of.
b) When only the ignore/disable annotation was added to a method without any change in the method, this was not taken as a method change, but only as a class change, combined with a) this led to these methods not being recognized as ignored/disabled either.