### PR TITLE
avoid overwriting properties line if is set

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/TestTaskParser.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/TestTaskParser.java
@@ -84,7 +84,7 @@ public class TestTaskParser {
    }
 
    private int getPropertiesLine(ExpressionStatement potentialSystemProperties) {
-      int propertiesLine = -1;
+      int propertiesLine = getPropertiesLine();
 
       MethodCallExpression methodCallExpression = (MethodCallExpression) potentialSystemProperties.getExpression();
       String method = methodCallExpression.getMethodAsString();


### PR DESCRIPTION
If there are more lines after the properties block or system Property inline in the parents section, the property line number will be overwritten.