### PR TITLE
Cleaned up TestJVMArgsGradle, don't add whitespace in ArgLineBuilder.getJVMArgs

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/kieker/ArgLineBuilder.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/kieker/ArgLineBuilder.java
@@ -130,7 +130,7 @@ public class ArgLineBuilder {
       String changedArgLine = getXmxArgLine(oldArgLine);
 
       if (!testTransformer.getConfig().getKiekerConfig().isUseSourceInstrumentation() || testTransformer.getConfig().getKiekerConfig().isOnlyOneCallRecording()) {
-         return "  jvmArgs=[\"" + KIEKER_ARG_LINE_GRADLE + "\", " + changedArgLine + "]";
+         return "  jvmArgs=[\"" + KIEKER_ARG_LINE_GRADLE + "\"," + changedArgLine + "]";
       } else {
          return changedArgLine;
       }

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -88,18 +88,12 @@ public class TestJVMArgsGradle {
 
    @Test
    public void testXmxIncreaseMegabyte() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgsInMegabyte.gradle");
+      final String[] testTasks = getTestTasks("buildJVMArgsInMegabyte.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -62,21 +62,12 @@ public class TestJVMArgsGradle {
 
    @Test
    public void testXmxSetting() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildNoJVMArgs.gradle");
-
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-
-      System.out.println(gradleFileContents);
+      final String[] testTasks = getTestTasks("buildNoJVMArgs.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -75,18 +75,12 @@ public class TestJVMArgsGradle {
 
    @Test
    public void testXmxIncreaseGigabyte() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgs.gradle");
+      final String[] testTasks = getTestTasks("buildJVMArgs.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -55,9 +55,11 @@ public class TestJVMArgsGradle {
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "maxHeapSize"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("maxHeapSize = \"5g\""));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("maxHeapSize = \"5g\""));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
    @Test
@@ -68,9 +70,11 @@ public class TestJVMArgsGradle {
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
    @Test
@@ -81,9 +85,11 @@ public class TestJVMArgsGradle {
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
    @Test
@@ -94,9 +100,11 @@ public class TestJVMArgsGradle {
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
    @Test
@@ -107,9 +115,11 @@ public class TestJVMArgsGradle {
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
    @Test
@@ -120,9 +130,11 @@ public class TestJVMArgsGradle {
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g\'"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g\'"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
    private String updateGradleFile(final File gradleFile) throws IOException {
@@ -143,5 +155,13 @@ public class TestJVMArgsGradle {
       final int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
 
       return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
+   }
+
+   private boolean checkJVMArgsContainWhitespace (final String task) {
+      final String jvmArgsPattern = "jvmArgs=[";
+      final int jvmArgsIndex = task.indexOf(jvmArgsPattern);
+      final String jvmArguments = task.substring(jvmArgsIndex + jvmArgsPattern.length(), task.lastIndexOf("]"));
+
+      return StringUtils.containsWhitespace(jvmArguments);
    }
 }

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -114,19 +114,12 @@ public class TestJVMArgsGradle {
 
    @Test
    public void testXmxDoubleArgs() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMDoubleArgs.gradle");
-
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
+      final String[] testTasks = getTestTasks("buildJVMDoubleArgs.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g\'"));
-
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g\'"));

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -101,19 +101,12 @@ public class TestJVMArgsGradle {
 
    @Test
    public void testXmxIncreaseSimple() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgsSimple.gradle");
-
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
+      final String[] testTasks = getTestTasks("buildJVMArgsSimple.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -49,21 +49,12 @@ public class TestJVMArgsGradle {
 
    @Test
    public void testHeapsizeReplacement() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "build.gradle");
-
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-
-      System.out.println(gradleFileContents);
+      final String[] testTasks = getTestTasks("build.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "maxHeapSize"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("maxHeapSize = \"5g\""));
-
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
 
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("maxHeapSize = \"5g\""));
@@ -177,5 +168,15 @@ public class TestJVMArgsGradle {
 
       final String gradleFileContents = FileUtils.readFileToString(destFile, Charset.defaultCharset());
       return gradleFileContents;
+   }
+
+   private String[] getTestTasks(final String gradleFileName) throws IOException {
+
+      final File gradleBuildFile = new File(GRADLE_BUILDFILE_FOLDER, gradleFileName);
+      final String gradleFileContents = updateGradleFile(gradleBuildFile);
+      final int testIndex = gradleFileContents.indexOf("test {");
+      final int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
+
+      return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
    }
 }

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -21,7 +21,7 @@ import de.dagere.peass.testtransformation.JUnitTestTransformer;
 import de.dagere.peass.testtransformation.JUnitVersions;
 
 public class TestJVMArgsGradle {
-   
+
    public static final File CURRENT = new File(new File("target"), "current_gradle");
 
    public static final File GRADLE_BUILDFILE_FOLDER = new File("src/test/resources/gradle");
@@ -42,11 +42,11 @@ public class TestJVMArgsGradle {
       if (CURRENT.exists()) {
          FileUtils.cleanDirectory(CURRENT);
       }
-      
+
       mockedTransformer.getConfig().getKiekerConfig().setOnlyOneCallRecording(true);
       mockedTransformer.getConfig().getExecutionConfig().setXmx("5g");
    }
-   
+
    @Test
    public void testHeapsizeReplacement() throws IOException {
       final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "build.gradle");
@@ -55,20 +55,20 @@ public class TestJVMArgsGradle {
 
       int testIndex = gradleFileContents.indexOf("test {");
       int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
+
       String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
+
       System.out.println(gradleFileContents);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "maxHeapSize"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("maxHeapSize = \"5g\""));
-      
+
       String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("maxHeapSize = \"5g\""));
    }
-   
+
    @Test
    public void testXmxSetting() throws IOException {
       final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildNoJVMArgs.gradle");
@@ -77,20 +77,20 @@ public class TestJVMArgsGradle {
 
       int testIndex = gradleFileContents.indexOf("test {");
       int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
+
       String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
+
       System.out.println(gradleFileContents);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
+
       String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
    }
-   
+
    @Test
    public void testXmxIncreaseGigabyte() throws IOException {
       final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgs.gradle");
@@ -99,17 +99,17 @@ public class TestJVMArgsGradle {
 
       int testIndex = gradleFileContents.indexOf("test {");
       int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
+
       String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
+
       String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
    }
-   
+
    @Test
    public void testXmxIncreaseMegabyte() throws IOException {
       final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgsInMegabyte.gradle");
@@ -118,17 +118,17 @@ public class TestJVMArgsGradle {
 
       int testIndex = gradleFileContents.indexOf("test {");
       int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
+
       String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
+
       String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
    }
-   
+
    @Test
    public void testXmxIncreaseSimple() throws IOException {
       final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgsSimple.gradle");
@@ -137,18 +137,18 @@ public class TestJVMArgsGradle {
 
       int testIndex = gradleFileContents.indexOf("test {");
       int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
+
       String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
+
       String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
    }
-   
+
    @Test
    public void testXmxDoubleArgs() throws IOException {
       final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMDoubleArgs.gradle");
@@ -157,18 +157,18 @@ public class TestJVMArgsGradle {
 
       int testIndex = gradleFileContents.indexOf("test {");
       int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
+
       String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g\'"));
-      
+
       String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g\'"));
    }
-   
+
    private String updateGradleFile(final File gradleFile) throws IOException {
       final File destFile = GradleTestUtil.initProject(gradleFile, CURRENT);
 


### PR DESCRIPTION
- Removed unused import und reformated TestJVMArgsGradle
- Extracted getTestTasks since this repeated in every test
- Added check for whitespaces in jvmArguments for testTask and integrationTestTask
- Removed adding whitespace in ArgLineBuilder.getJVMArgs