### PR TITLE
Clean after checkout a commit

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleTestExecutor.java
@@ -194,7 +194,7 @@ public class GradleTestExecutor extends KoPeMeExecutor {
 
          final String[] vars;
          if (!isAndroid) {
-            vars = new String[] { EnvironmentVariables.fetchGradleCall(), "--no-daemon", "testClasses", "assemble" };
+            vars = new String[] { EnvironmentVariables.fetchGradleCall(), "--no-daemon", getCleanGoal(), "testClasses", "assemble" };
          } else {
             vars = new String[] { EnvironmentVariables.fetchGradleCall(), "--no-daemon", "assemble" };
          }


### PR DESCRIPTION
Sometimes the generated data from previous build causes an error. To fix the problem it is clean up after checkout next commit necessary 