### PR TITLE
Corrected TestJVMArgsGradle, provide failing test for adding aspectJ if no testblock is present

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -237,9 +237,9 @@ public class GradleBuildfileEditor {
 
          if (visitor.getTestTaskProperties() != null) {
             TestTaskParser testTaskProperties = visitor.getTestTaskProperties();
-            adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getLines().size() - 1);
+            adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getLines().size() - 2);
          } else {
-            adaptTask(visitor, argLineBuilder, null, visitor.getLines().size() - 1);
+            adaptTask(visitor, argLineBuilder, null, visitor.getLines().size() - 2);
          }
 
       }

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -198,7 +198,7 @@ public class GradleBuildfileEditor {
 
    private void adaptTask(final GradleBuildfileVisitor visitor, final ArgLineBuilder argLineBuilder, TestTaskParser integrationTestTaskProperties, int testTaskLine) {
       if (argLineBuilder.getJVMArgs() != null) {
-         if (integrationTestTaskProperties.getJvmArgsLine() != -1) {
+         if (integrationTestTaskProperties != null && integrationTestTaskProperties.getJvmArgsLine() != -1) {
             String taskWithoutQuotations = integrationTestTaskProperties.getTestJvmArgsText().substring(1, integrationTestTaskProperties.getTestJvmArgsText().length() - 1);
             String testJvmArgsText = "'" + // args should start by ' 
                   taskWithoutQuotations 
@@ -211,7 +211,7 @@ public class GradleBuildfileEditor {
             visitor.addLine(testTaskLine, argLineBuilder.getJVMArgs());
          }
       }
-      if (integrationTestTaskProperties.getMaxHeapSizeLine() != -1 && testTransformer.getConfig().getExecutionConfig().getXmx() != null) {
+      if (integrationTestTaskProperties != null && integrationTestTaskProperties.getMaxHeapSizeLine() != -1 && testTransformer.getConfig().getExecutionConfig().getXmx() != null) {
          visitor.getLines().set(integrationTestTaskProperties.getMaxHeapSizeLine() -1, "    maxHeapSize = \"" + testTransformer.getConfig().getExecutionConfig().getXmx() + "\"");
       }
    }

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -231,7 +231,17 @@ public class GradleBuildfileEditor {
          adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getTestLine() - 1);
 
       } else {
-         visitor.getLines().add("test { " + argLineBuilder.buildSystemPropertiesGradle(tempFolder) + "}");
+         visitor.addLine(visitor.getLines().size() - 1, "test {");
+         visitor.addLine(visitor.getLines().size() - 1, argLineBuilder.buildSystemPropertiesGradle(tempFolder));
+         visitor.addLine(visitor.getLines().size() - 1, "}");
+
+         if (visitor.getTestTaskProperties() != null) {
+            TestTaskParser testTaskProperties = visitor.getTestTaskProperties();
+            adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getLines().size() - 1);
+         } else {
+            adaptTask(visitor, argLineBuilder, null, visitor.getLines().size() - 1);
+         }
+
       }
    }
 }

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -137,6 +137,13 @@ public class TestJVMArgsGradle {
       Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
+   @Test
+   public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock() throws IOException {
+      final String[] testTasks = getTestTasks("minimalGradleEmptyTestblock.gradle");
+      final String testTask = testTasks[0];
+      Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
+   }
+
    private String updateGradleFile(final File gradleFile) throws IOException {
       final File destFile = GradleTestUtil.initProject(gradleFile, CURRENT);
 

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -145,8 +145,6 @@ public class TestJVMArgsGradle {
       Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
    }
 
-   //This fails, if you have no testblock at all
-   @Ignore
    @Test
    public void testAspectJAddedWithOnlyOneCallRecordingAndNoTestBlock() throws IOException {
       final String[] testTasks = getTestTasks("minimalGradleNoTestblock.gradle");

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -154,7 +154,12 @@ public class TestJVMArgsGradle {
       final int testIndex = gradleFileContents.indexOf("test {");
       final int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
 
-      return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
+      if (integrationTestIndex != -1) {
+         return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
+      } else {
+         final String testTaskTillEOF = gradleFileContents.substring(testIndex);
+         return new String[] { testTaskTillEOF.substring(0, testTaskTillEOF.indexOf("}")), "" };
+      }
    }
 
    private boolean checkJVMArgsContainWhitespace (final String task) {

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -165,7 +165,7 @@ public class TestJVMArgsGradle {
          return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
       } else {
          final String testTaskTillEOF = gradleFileContents.substring(testIndex);
-         return new String[] { testTaskTillEOF.substring(0, testTaskTillEOF.indexOf("}")), "" };
+         return new String[] { testTaskTillEOF.substring(0, testTaskTillEOF.lastIndexOf("}")), "" };
       }
    }
 

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -140,6 +141,15 @@ public class TestJVMArgsGradle {
    @Test
    public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock() throws IOException {
       final String[] testTasks = getTestTasks("minimalGradleEmptyTestblock.gradle");
+      final String testTask = testTasks[0];
+      Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
+   }
+
+   //This fails, if you have no testblock at all
+   @Ignore
+   @Test
+   public void testAspectJAddedWithOnlyOneCallRecordingAndNoTestBlock() throws IOException {
+      final String[] testTasks = getTestTasks("minimalGradleNoTestblock.gradle");
       final String testTask = testTasks[0];
       Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
    }

--- a/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java'
+
+test {
+
+}

--- a/dependency/src/test/resources/gradle/minimalGradleNoTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleNoTestblock.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'java'


### PR DESCRIPTION
For [issue #202](https://github.com/jenkinsci/peass-ci-plugin/issues/202) I added gradle-files and appropriate tests to check, if aspectJ-library is added to jvmArgs if no test-block is present.
testAspectJAddedWithOnlyOneCallRecordingAndNoTestBlock currently fails and is therefore ignored.