### PR TITLE
Extended testing for aspectJ-adding

### DIFF
--- a/dependency/pom.xml
+++ b/dependency/pom.xml
@@ -187,9 +187,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-astbuilder</artifactId>
-      <version>3.0.13</version>
+      <version>4.0.6</version>
     </dependency>
 
     <dependency>

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -198,7 +198,7 @@ public class GradleBuildfileEditor {
 
    private void adaptTask(final GradleBuildfileVisitor visitor, final ArgLineBuilder argLineBuilder, TestTaskParser integrationTestTaskProperties, int testTaskLine) {
       if (argLineBuilder.getJVMArgs() != null) {
-         if (integrationTestTaskProperties.getJvmArgsLine() != -1) {
+         if (integrationTestTaskProperties != null && integrationTestTaskProperties.getJvmArgsLine() != -1) {
             String taskWithoutQuotations = integrationTestTaskProperties.getTestJvmArgsText().substring(1, integrationTestTaskProperties.getTestJvmArgsText().length() - 1);
             String testJvmArgsText = "'" + // args should start by ' 
                   taskWithoutQuotations 
@@ -211,7 +211,7 @@ public class GradleBuildfileEditor {
             visitor.addLine(testTaskLine, argLineBuilder.getJVMArgs());
          }
       }
-      if (integrationTestTaskProperties.getMaxHeapSizeLine() != -1 && testTransformer.getConfig().getExecutionConfig().getXmx() != null) {
+      if (integrationTestTaskProperties != null && integrationTestTaskProperties.getMaxHeapSizeLine() != -1 && testTransformer.getConfig().getExecutionConfig().getXmx() != null) {
          visitor.getLines().set(integrationTestTaskProperties.getMaxHeapSizeLine() -1, "    maxHeapSize = \"" + testTransformer.getConfig().getExecutionConfig().getXmx() + "\"");
       }
    }
@@ -231,7 +231,17 @@ public class GradleBuildfileEditor {
          adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getTestLine() - 1);
 
       } else {
-         visitor.getLines().add("test { " + argLineBuilder.buildSystemPropertiesGradle(tempFolder) + "}");
+         visitor.addLine(visitor.getLines().size() - 1, "test {");
+         visitor.addLine(visitor.getLines().size() - 1, argLineBuilder.buildSystemPropertiesGradle(tempFolder));
+         visitor.addLine(visitor.getLines().size() - 1, "}");
+
+         if (visitor.getTestTaskProperties() != null) {
+            TestTaskParser testTaskProperties = visitor.getTestTaskProperties();
+            adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getLines().size() - 2);
+         } else {
+            adaptTask(visitor, argLineBuilder, null, visitor.getLines().size() - 2);
+         }
+
       }
    }
 }

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleTestExecutor.java
@@ -194,7 +194,7 @@ public class GradleTestExecutor extends KoPeMeExecutor {
 
          final String[] vars;
          if (!isAndroid) {
-            vars = new String[] { EnvironmentVariables.fetchGradleCall(), "--no-daemon", "testClasses", "assemble" };
+            vars = new String[] { EnvironmentVariables.fetchGradleCall(), "--no-daemon", getCleanGoal(), "testClasses", "assemble" };
          } else {
             vars = new String[] { EnvironmentVariables.fetchGradleCall(), "--no-daemon", "assemble" };
          }

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleTestExecutor.java
@@ -100,7 +100,7 @@ public class GradleTestExecutor extends KoPeMeExecutor {
     * Executes the Gradle process; since gradle is run inside the module folder, different parameters than for the maven execution are required
     */
    private Process buildGradleProcess(final File moduleFolder, final File logFile, TestMethodCall test, final String... commandLineAddition)
-         throws IOException, XmlPullParserException {
+         throws IOException {
       final String testGoal = getTestGoal();
       String wrapper = new File(folders.getProjectFolder(), EnvironmentVariables.fetchGradleCall()).getAbsolutePath();
       String[] originals = new String[] { wrapper,
@@ -159,7 +159,7 @@ public class GradleTestExecutor extends KoPeMeExecutor {
          execute(testname, timeout, process);
 
          GradleDaemonFileDeleter.deleteDaemonFile(methodLogFile);
-      } catch (final IOException | XmlPullParserException e) {
+      } catch (final IOException e) {
          e.printStackTrace();
       }
    }

--- a/dependency/src/main/java/de/dagere/peass/execution/kieker/ArgLineBuilder.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/kieker/ArgLineBuilder.java
@@ -130,7 +130,7 @@ public class ArgLineBuilder {
       String changedArgLine = getXmxArgLine(oldArgLine);
 
       if (!testTransformer.getConfig().getKiekerConfig().isUseSourceInstrumentation() || testTransformer.getConfig().getKiekerConfig().isOnlyOneCallRecording()) {
-         return "  jvmArgs=[\"" + KIEKER_ARG_LINE_GRADLE + "\", " + changedArgLine + "]";
+         return "  jvmArgs=[\"" + KIEKER_ARG_LINE_GRADLE + "\"," + changedArgLine + "]";
       } else {
          return changedArgLine;
       }

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -22,7 +21,7 @@ import de.dagere.peass.testtransformation.JUnitTestTransformer;
 import de.dagere.peass.testtransformation.JUnitVersions;
 
 public class TestJVMArgsGradle {
-   
+
    public static final File CURRENT = new File(new File("target"), "current_gradle");
 
    public static final File GRADLE_BUILDFILE_FOLDER = new File("src/test/resources/gradle");
@@ -43,133 +42,101 @@ public class TestJVMArgsGradle {
       if (CURRENT.exists()) {
          FileUtils.cleanDirectory(CURRENT);
       }
-      
+
       mockedTransformer.getConfig().getKiekerConfig().setOnlyOneCallRecording(true);
       mockedTransformer.getConfig().getExecutionConfig().setXmx("5g");
    }
-   
+
    @Test
    public void testHeapsizeReplacement() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "build.gradle");
+      final String[] testTasks = getTestTasks("build.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
-      System.out.println(gradleFileContents);
-      
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "maxHeapSize"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("maxHeapSize = \"5g\""));
-      
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("maxHeapSize = \"5g\""));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
-   
+
    @Test
    public void testXmxSetting() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildNoJVMArgs.gradle");
+      final String[] testTasks = getTestTasks("buildNoJVMArgs.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
-      System.out.println(gradleFileContents);
-      
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
-   
+
    @Test
    public void testXmxIncreaseGigabyte() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgs.gradle");
+      final String[] testTasks = getTestTasks("buildJVMArgs.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
-   
+
    @Test
    public void testXmxIncreaseMegabyte() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgsInMegabyte.gradle");
+      final String[] testTasks = getTestTasks("buildJVMArgsInMegabyte.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
-   
+
    @Test
    public void testXmxIncreaseSimple() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMArgsSimple.gradle");
+      final String[] testTasks = getTestTasks("buildJVMArgsSimple.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g"));
-      
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
-   
+
    @Test
    public void testXmxDoubleArgs() throws IOException {
-      final File gradleFile = new File(GRADLE_BUILDFILE_FOLDER, "buildJVMDoubleArgs.gradle");
+      final String[] testTasks = getTestTasks("buildJVMDoubleArgs.gradle");
+      final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
 
-      final String gradleFileContents = updateGradleFile(gradleFile);
-
-      int testIndex = gradleFileContents.indexOf("test {");
-      int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
-      
-      String testTask = gradleFileContents.substring(testIndex, integrationTestIndex);
-      
       Assert.assertEquals(1, StringUtils.countMatches(testTask, "jvmArgs"));
       MatcherAssert.assertThat(testTask, Matchers.containsString("-Xmx5g\'"));
-      
-      String integrationTestTask = gradleFileContents.substring(integrationTestIndex);
-      
+      Assert.assertFalse(checkJVMArgsContainWhitespace(testTask));
+
       Assert.assertEquals(1, StringUtils.countMatches(integrationTestTask, "jvmArgs"));
       MatcherAssert.assertThat(integrationTestTask, Matchers.containsString("-Xmx5g\'"));
+      Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
-   
+
    private String updateGradleFile(final File gradleFile) throws IOException {
       final File destFile = GradleTestUtil.initProject(gradleFile, CURRENT);
 
@@ -178,5 +145,23 @@ public class TestJVMArgsGradle {
 
       final String gradleFileContents = FileUtils.readFileToString(destFile, Charset.defaultCharset());
       return gradleFileContents;
+   }
+
+   private String[] getTestTasks(final String gradleFileName) throws IOException {
+
+      final File gradleBuildFile = new File(GRADLE_BUILDFILE_FOLDER, gradleFileName);
+      final String gradleFileContents = updateGradleFile(gradleBuildFile);
+      final int testIndex = gradleFileContents.indexOf("test {");
+      final int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
+
+      return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
+   }
+
+   private boolean checkJVMArgsContainWhitespace (final String task) {
+      final String jvmArgsPattern = "jvmArgs=[";
+      final int jvmArgsIndex = task.indexOf(jvmArgsPattern);
+      final String jvmArguments = task.substring(jvmArgsIndex + jvmArgsPattern.length(), task.lastIndexOf("]"));
+
+      return StringUtils.containsWhitespace(jvmArguments);
    }
 }

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -139,10 +138,12 @@ public class TestJVMArgsGradle {
    }
 
    @Test
-   public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock() throws IOException {
-      final String[] testTasks = getTestTasks("minimalGradleEmptyTestblock.gradle");
+   public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlocks() throws IOException {
+      final String[] testTasks = getTestTasks("minimalGradleEmptyTestblocks.gradle");
       final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
       Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
+      Assert.assertTrue(integrationTestTask.contains("jvmArgs=[") && integrationTestTask.contains("aspectj.jar"));
    }
 
    @Test

--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -137,6 +138,20 @@ public class TestJVMArgsGradle {
       Assert.assertFalse(checkJVMArgsContainWhitespace(integrationTestTask));
    }
 
+   @Test
+   public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock() throws IOException {
+      final String[] testTasks = getTestTasks("minimalGradleEmptyTestblock.gradle");
+      final String testTask = testTasks[0];
+      Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
+   }
+
+   @Test
+   public void testAspectJAddedWithOnlyOneCallRecordingAndNoTestBlock() throws IOException {
+      final String[] testTasks = getTestTasks("minimalGradleNoTestblock.gradle");
+      final String testTask = testTasks[0];
+      Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
+   }
+
    private String updateGradleFile(final File gradleFile) throws IOException {
       final File destFile = GradleTestUtil.initProject(gradleFile, CURRENT);
 
@@ -154,7 +169,12 @@ public class TestJVMArgsGradle {
       final int testIndex = gradleFileContents.indexOf("test {");
       final int integrationTestIndex = gradleFileContents.indexOf("task integrationTest");
 
-      return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
+      if (integrationTestIndex != -1) {
+         return new String[] { gradleFileContents.substring(testIndex, integrationTestIndex), gradleFileContents.substring(integrationTestIndex) };
+      } else {
+         final String testTaskTillEOF = gradleFileContents.substring(testIndex);
+         return new String[] { testTaskTillEOF.substring(0, testTaskTillEOF.lastIndexOf("}")), "" };
+      }
    }
 
    private boolean checkJVMArgsContainWhitespace (final String task) {

--- a/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
@@ -1,5 +1,0 @@
-apply plugin: 'java'
-
-test {
-
-}

--- a/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java'
+
+test {
+
+}

--- a/dependency/src/test/resources/gradle/minimalGradleEmptyTestblocks.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleEmptyTestblocks.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'java'
+
+sourceSets {
+    intTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    intTestImplementation.extendsFrom implementation
+    intTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+
+    intTestImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+}
+
+test {
+
+}
+
+task integrationTest(type: Test) {
+    
+}

--- a/dependency/src/test/resources/gradle/minimalGradleNoTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleNoTestblock.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'java'

--- a/measurement/src/main/java/de/dagere/peass/measurement/dependencyprocessors/reductioninfos/ReductionManager.java
+++ b/measurement/src/main/java/de/dagere/peass/measurement/dependencyprocessors/reductioninfos/ReductionManager.java
@@ -44,7 +44,7 @@ public class ReductionManager {
             
             try {
                File reductionFile = organizer.getFolders().getReductionFile(testcase);
-               Constants.OBJECTMAPPER.writeValue(reductionFile, commitCurrentResult);
+               Constants.OBJECTMAPPER.writeValue(reductionFile, reductionInformation);
             } catch (IOException e) {
                e.printStackTrace();
             }

--- a/measurement/src/main/java/de/dagere/peass/measurement/dependencyprocessors/reductioninfos/ReductionManager.java
+++ b/measurement/src/main/java/de/dagere/peass/measurement/dependencyprocessors/reductioninfos/ReductionManager.java
@@ -37,7 +37,8 @@ public class ReductionManager {
          if (reducedIterations != measurementConfig.getIterations()) {
             reductionInformation.addReduction(vmid, reductionOld, reductionCurrent);
 
-            LOG.error("Should originally run {} iterations, but did not succeed - reducing to {}", measurementConfig.getIterations(), reducedIterations);
+            LOG.error("Should originally run {} iterations, but did not succeed (because of {}) - reducing to {}", 
+                  measurementConfig.getIterations(), reductionOld.getReason() + " - " + reductionCurrent.getReason(), reducedIterations);
             // final int lessIterations = testTransformer.getConfig().getIterations() / 5;
             shouldBreak = reduceExecutions(shouldBreak, reducedIterations);
             

--- a/peass-jmh/pom.xml
+++ b/peass-jmh/pom.xml
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.8.0</version>
+      <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.8.0</version>
+      <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
   </build>
 
   <properties>
-    <mockito.version>4.8.0</mockito.version>
+    <mockito.version>4.8.1</mockito.version>
     <junit.version>5.9.1</junit.version>
     <kieker.version>1.15.1</kieker.version>
     <kopeme.version>1.1.13</kopeme.version>


### PR DESCRIPTION
- Renamed testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock (just added s), since it now checks also adding of aspectJ-library to jvmArgs for IT if an empty integrationTest-block is present.

- Adapted/renamed the appropriate gradle testfile.