### PR TITLE
Extended testing for aspectJ-adding

### DIFF
--- a/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/execution/gradle/TestJVMArgsGradle.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -139,10 +138,12 @@ public class TestJVMArgsGradle {
    }
 
    @Test
-   public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock() throws IOException {
-      final String[] testTasks = getTestTasks("minimalGradleEmptyTestblock.gradle");
+   public void testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlocks() throws IOException {
+      final String[] testTasks = getTestTasks("minimalGradleEmptyTestblocks.gradle");
       final String testTask = testTasks[0];
+      final String integrationTestTask = testTasks[1];
       Assert.assertTrue(testTask.contains("jvmArgs=[") && testTask.contains("aspectj.jar"));
+      Assert.assertTrue(integrationTestTask.contains("jvmArgs=[") && integrationTestTask.contains("aspectj.jar"));
    }
 
    @Test

--- a/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleEmptyTestblock.gradle
@@ -1,5 +1,0 @@
-apply plugin: 'java'
-
-test {
-
-}

--- a/dependency/src/test/resources/gradle/minimalGradleEmptyTestblocks.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleEmptyTestblocks.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'java'
+
+sourceSets {
+    intTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    intTestImplementation.extendsFrom implementation
+    intTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+
+    intTestImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+}
+
+test {
+
+}
+
+task integrationTest(type: Test) {
+    
+}


### PR DESCRIPTION
- Renamed testAspectJAddedWithOnlyOneCallRecordingAndEmptyTestBlock (just added s), since it now checks also adding of aspectJ-library to jvmArgs for IT if an empty integrationTest-block is present.

- Adapted/renamed the appropriate gradle testfile.