### PR TITLE
Fixed adding of aspectJ-line for IT if onlyOneCallRecording is set

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -231,9 +231,9 @@ public class GradleBuildfileEditor {
          adaptTask(visitor, argLineBuilder, testTaskProperties, visitor.getTestLine() - 1);
 
       } else {
-         visitor.addLine(visitor.getLines().size() - 1, "test {");
-         visitor.addLine(visitor.getLines().size() - 1, argLineBuilder.buildSystemPropertiesGradle(tempFolder));
-         visitor.addLine(visitor.getLines().size() - 1, "}");
+         visitor.addLine(visitor.getLines().size(), "test {");
+         visitor.addLine(visitor.getLines().size(), argLineBuilder.buildSystemPropertiesGradle(tempFolder));
+         visitor.addLine(visitor.getLines().size(), "}");
 
          if (visitor.getTestTaskProperties() != null) {
             TestTaskParser testTaskProperties = visitor.getTestTaskProperties();

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/GradleBuildfileEditor.java
@@ -192,7 +192,16 @@ public class GradleBuildfileEditor {
          TestTaskParser integrationTestTaskProperties = visitor.getIntegrationTestTaskProperties();
          adaptTask(visitor, argLineBuilder, integrationTestTaskProperties, visitor.getIntegrationTestLine() - 1);
       } else if (taskAnalyzer.isIntegrationTest()) {
-         visitor.getLines().add("integrationTest { " + argLineBuilder.buildSystemPropertiesGradle(tempFolder) + "}");
+         visitor.addLine(visitor.getLines().size(), "integrationTest {");
+         visitor.addLine(visitor.getLines().size(), argLineBuilder.buildSystemPropertiesGradle(tempFolder));
+         visitor.addLine(visitor.getLines().size(), "}");
+
+         if (visitor.getIntegrationTestTaskProperties() != null) {
+            TestTaskParser integrationTestTaskProperties = visitor.getIntegrationTestTaskProperties();
+            adaptTask(visitor, argLineBuilder, integrationTestTaskProperties, visitor.getLines().size() - 2);
+         } else {
+            adaptTask(visitor, argLineBuilder, null, visitor.getLines().size() - 2);
+         }
       }
    }
 

--- a/dependency/src/test/resources/gradle/minimalGradleNoTestblock.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleNoTestblock.gradle
@@ -1,1 +1,0 @@
-apply plugin: 'java'

--- a/dependency/src/test/resources/gradle/minimalGradleNoTestblocks.gradle
+++ b/dependency/src/test/resources/gradle/minimalGradleNoTestblocks.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'java'
+
+sourceSets {
+    intTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    intTestImplementation.extendsFrom implementation
+    intTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
+dependencies {
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+
+    intTestImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs integration tests.'
+    group = 'verification'
+
+    testClassesDirs = sourceSets.intTest.output.classesDirs
+    classpath = sourceSets.intTest.runtimeClasspath
+    shouldRunAfter test
+}


### PR DESCRIPTION
- You can register IT with "tasks.register('integrationTest', Test) {...}" also. In this case it was not recognized, that module has IT-task.
- testBlock was put inside IT-block, fixed this
- had to add IT-block and adaptTask for IT if build.gradle had no integrationTestLine but IT-task existed