### PR TITLE
Fixed detection of gradle module-names

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/SettingsFileParser.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/SettingsFileParser.java
@@ -86,7 +86,7 @@ public class SettingsFileParser {
       if (splitted[0].equals("include")) {
          for (int candidateIndex = 1; candidateIndex < splitted.length; candidateIndex++) {
             final String candidate = splitted[candidateIndex].substring(1, splitted[candidateIndex].length() - 1);
-            String folderName = prefix + candidate.replace(':', File.separatorChar) + suffix;
+            String folderName = prefix + candidate.replace(":", "") + suffix;
             final File module = new File(projectFolder, folderName);
             if (module.exists()) {
                modules.add(module);


### PR DESCRIPTION
If you modify gradle module-names in settings.gradle like this:
```
rootProject.children.each { subproject ->
     subproject.projectDir = file("module-" + subproject.name)
 } 
```
peass added a "/" between prefix and suffix, resulting in "module-/subproject.name".
I removed adding the "/".