### PR TITLE
Write configuration file to pass env variables/properties for Android projects.

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
@@ -12,8 +12,8 @@ import de.dagere.peass.execution.utils.CommandConcatenator;
 import de.dagere.peass.execution.utils.EnvironmentVariables;
 import de.dagere.peass.folders.PeassFolders;
 import de.dagere.peass.testtransformation.JUnitTestTransformer;
+import de.dagere.peass.utils.Constants;
 import de.dagere.peass.utils.StreamGobbler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class AnboxTestExecutor extends GradleTestExecutor {
@@ -48,14 +48,13 @@ public class AnboxTestExecutor extends GradleTestExecutor {
     * Writes Android configuration file inside "app/src/main/resources" to pass values for KoPeMe inside the emulator.
     */
    private void writeAndroidConfigJson() {
-      ObjectMapper mapper = new ObjectMapper();
-      ObjectNode androidConfig = mapper.createObjectNode();
+      ObjectNode androidConfig = Constants.OBJECTMAPPER.createObjectNode();
       androidConfig.put("KOPEME_HOME", ANBOX_EMULATOR_FOLDER_TEMP_RESULT);
       // TODO: Change the hard coded module name 'app'.
       androidConfig.put("kopeme.workingdir", ANBOX_EMULATOR_FOLDER_BASE + "app");
       File kopemeConfig = new File(folders.getProjectFolder() + "/" + ANDROID_RESOURCES_FOLDER + ANDROID_KOPEME_CONFIGURATION);
       try {
-         mapper.writerWithDefaultPrettyPrinter().writeValue(kopemeConfig, androidConfig);
+         Constants.OBJECTMAPPER.writerWithDefaultPrettyPrinter().writeValue(kopemeConfig, androidConfig);
       } catch (IOException e) {
          throw new RuntimeException(e);
       }


### PR DESCRIPTION
Creates a configuration file `kopeme_config.json` for Android projects inside its resources folder.
Writes the values of `"KOPEME_HOME"` environment variable and `"kopeme.workingdir"` property into it.