### PR TITLE
Fix test package name and missing env variables

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
@@ -55,10 +55,12 @@ public class AnboxTestExecutor extends GradleTestExecutor {
       // TODO: Change the hard coded module name 'app'.
       androidConfig.put("kopeme.workingdir", ANBOX_EMULATOR_FOLDER_BASE + "app");
       File kopemeConfig = new File(folders.getProjectFolder() + "/" + ANDROID_RESOURCES_FOLDER + ANDROID_KOPEME_CONFIGURATION);
+      LOG.debug("Creating file: {} with content: {}", kopemeConfig, androidConfig.toString());
       try {
          kopemeConfig.getParentFile().mkdirs();
          Constants.OBJECTMAPPER.writerWithDefaultPrettyPrinter().writeValue(kopemeConfig, androidConfig);
       } catch (IOException e) {
+         LOG.error(e.getMessage());
          throw new RuntimeException(e);
       }
    }
@@ -87,6 +89,7 @@ public class AnboxTestExecutor extends GradleTestExecutor {
       List<String> gradleTasks = testTransformer.getConfig().getExecutionConfig().getAndroidGradleTasks();
 
       String[] processArgs = toMergedArray(wrapper, gradleTasks);
+      LOG.debug("Command: {}", Arrays.toString(processArgs));
 
       ProcessBuilder builder = new ProcessBuilder(processArgs);
       builder.directory(folders.getProjectFolder());
@@ -97,8 +100,10 @@ public class AnboxTestExecutor extends GradleTestExecutor {
 
       try {
          Process process = builder.start();
-         StreamGobbler.showFullProcess(process);
+         String processOutput = StreamGobbler.getFullProcess(process, true);
+         LOG.debug(processOutput);
       } catch (IOException e) {
+         LOG.error(e.getMessage());
          throw new RuntimeException(e);
       }
    }
@@ -159,8 +164,10 @@ public class AnboxTestExecutor extends GradleTestExecutor {
 
       try {
          Process process = builder.start();
-         StreamGobbler.showFullProcess(process);
+         String processOutput = StreamGobbler.getFullProcess(process, true);
+         LOG.debug(processOutput);
       } catch (IOException e) {
+         LOG.error(e.getMessage());
          throw new RuntimeException(e);
       }
    }
@@ -174,8 +181,10 @@ public class AnboxTestExecutor extends GradleTestExecutor {
       LOG.debug("ADB: Pulling {} to {}", ANBOX_EMULATOR_FOLDER_TEMP_RESULT, folders.getPeassFolder());
       try {
          Process process = builder.start();
-         StreamGobbler.showFullProcess(process);
+         String processOutput = StreamGobbler.getFullProcess(process, true);
+         LOG.debug(processOutput);
       } catch (IOException e) {
+         LOG.error(e.getMessage());
          throw new RuntimeException(e);
       }
    }

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
@@ -90,6 +90,10 @@ public class AnboxTestExecutor extends GradleTestExecutor {
 
       ProcessBuilder builder = new ProcessBuilder(processArgs);
       builder.directory(folders.getProjectFolder());
+      for (Map.Entry<String, String> entry : env.getEnvironmentVariables().entrySet()) {
+         LOG.trace("Environment: {} = {}", entry.getKey(), entry.getValue());
+         builder.environment().put(entry.getKey(), entry.getValue());
+      }
 
       try {
          Process process = builder.start();

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
@@ -2,7 +2,9 @@ package de.dagere.peass.execution.gradle;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -196,13 +198,26 @@ public class AnboxTestExecutor extends GradleTestExecutor {
 
       String[] anboxOriginals = new String[] { adbCall, "shell", "am", "instrument", "-w", "-e", "class" };
 
+      final String testPackageName = getTestPackageName(test);
+
       final String[] vars = CommandConcatenator.concatenateCommandArrays(anboxOriginals,
-            new String[] { test.getExecutable(), test.getPackage() + ".test" + "/androidx.test.runner.AndroidJUnitRunner" });
+            new String[] { test.getExecutable(), testPackageName + "/androidx.test.runner.AndroidJUnitRunner" });
       ProcessBuilderHelper processBuilderHelper = new ProcessBuilderHelper(env, folders);
       processBuilderHelper.parseParams(test.getParams());
 
       LOG.debug("Executing gradle test in moduleFolder: {}", moduleFolder);
       return processBuilderHelper.buildFolderProcess(moduleFolder, logFile, vars);
+   }
+
+   public static String getTestPackageName(TestMethodCall test) {
+      final String testPackageName;
+
+      if (test.getPackage().endsWith(".test")) {
+         testPackageName = test.getPackage();
+      } else {
+         testPackageName = test.getPackage() + ".test";
+      }
+      return testPackageName;
    }
 
    /**

--- a/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/gradle/AnboxTestExecutor.java
@@ -42,7 +42,7 @@ public class AnboxTestExecutor extends GradleTestExecutor {
 
       writeAndroidConfigJson();
       updateAndroidManifest();
-      adbPush();      
+      adbPush();
       compileSources();
    }
 

--- a/dependency/src/test/java/de/dagere/peass/dependency/TestAnboxTestExecutor.java
+++ b/dependency/src/test/java/de/dagere/peass/dependency/TestAnboxTestExecutor.java
@@ -1,0 +1,21 @@
+package de.dagere.peass.dependency;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import de.dagere.peass.dependency.analysis.testData.TestMethodCall;
+import de.dagere.peass.execution.gradle.AnboxTestExecutor;
+
+public class TestAnboxTestExecutor {
+   
+   @Test
+   public void testGetTestPackageName(){
+      TestMethodCall test;
+      
+      test = new TestMethodCall("my.package.Clazz", "method");
+      Assert.assertEquals("my.package.test", AnboxTestExecutor.getTestPackageName(test));
+
+      test = new TestMethodCall("my.package.test.Clazz", "method");
+      Assert.assertEquals("my.package.test", AnboxTestExecutor.getTestPackageName(test));
+   }
+}


### PR DESCRIPTION
Fixes:
- missing env variables in gradle install tasks
- wrong package name

ADB executes wrong test because of wrong package name. 
If test has this project package `com.my.package.app.test`, then the command will be `am instrument -w com.my.package.app.test.test`.

Tests in the `android-example-project` have the package name  `com.example.android_example` but ADB instrument command expects the name to be `com.example.android_example.test`. 
