### PR TITLE
Changed message if trace is empty and loglevel to warn

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/dependency/traces/OneTraceGenerator.java
+++ b/dependency/src/main/java/de/dagere/peass/dependency/traces/OneTraceGenerator.java
@@ -103,7 +103,7 @@ public class OneTraceGenerator {
 
                   success = true;
                } else {
-                  LOG.error("Trace empty!");
+                  LOG.warn("Trace is empty! (Which is ok for first execution of a parameterized test.)");
                }
             }
          } else {


### PR DESCRIPTION
I changed the message "ERROR de.dagere.peass.dependency.traces.OneTraceGenerator:106 - Trace empty!" and the loglevel from error to warn. Message is misleading for parameterized tests, since behaviour is right in this case.