### PR TITLE
Get full commit name

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
+++ b/dependency/src/main/java/de/dagere/peass/vcs/GitUtils.java
@@ -259,7 +259,7 @@ public final class GitUtils {
    }
 
    private static List<String> getCommitNames(final File folder, final boolean includeAllBranches) throws IOException {
-      String command = includeAllBranches ? "git log --oneline --all" : "git log --oneline";
+      String command = includeAllBranches ? "git log --oneline --all --no-abbrev-commit" : "git log --oneline --no-abbrev-commit";
       final Process p = Runtime.getRuntime().exec(command, new String[0], folder);
       try (final BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
          String line;


### PR DESCRIPTION
Short commit name lead to "fileterList" method skip all commit names and not found the commit.
Adding "--no-abbrev-commit" to command, get Full commit name
