### PR TITLE
fix twice dependency

### DIFF
--- a/dependency/src/main/java/de/dagere/peass/execution/utils/RequiredDependency.java
+++ b/dependency/src/main/java/de/dagere/peass/execution/utils/RequiredDependency.java
@@ -43,7 +43,12 @@ public class RequiredDependency {
    }
 
    public String getGradleDependency() {
-      String gradleDependencyString = groupId + ":" + artifactId + ":" + version;
+      String gradleDependencyString;
+      if (classifier == null) {
+         gradleDependencyString = groupId + ":" + artifactId + ":" + version;
+      } else {
+         gradleDependencyString = groupId + ":" + artifactId + ":" + version + ":" + classifier;
+      }
       return gradleDependencyString;
    }
 


### PR DESCRIPTION
If a classifier is defined, it should also be specified in the Gradle dependency.